### PR TITLE
Correctly stop advertising Webmention endpoint on ignore_paths.

### DIFF
--- a/webmention.php
+++ b/webmention.php
@@ -180,7 +180,7 @@ class WebmentionPlugin extends Plugin
         $base = $uri->base();
         $rcvr_route = $config->get('plugins.webmention.receiver.route');
         $rcvr_url = $base.$rcvr_route;
-        header('Link: &lt;'.$rcvr_url.'&gt;; rel="webmention"', false);
+        header('Link: <'.$rcvr_url.'>; rel="webmention"', false);
     }
 
     public function advertise_link(Event $e) {


### PR DESCRIPTION
This changes `advertise_link()` to better filter on what pages the LINK element has to be inserted. This fixes #5.

I removed the filter based on `plugins.webmention.sender.ignore_routes` because the Webmention endpoint should not care about this. Even if I do not want to send Webmentions from a specific set of pages, they are still allowed to receive them.

Instead I have added support for `plugins.webmention.receiver.ignore_paths`. This matches the README: the Webmention endpoint will not accept mentions at these paths, so we do not need to advertise the endpoint on those either.

Otherwise the plugin will only add the LINK element if:

1. the current output is known to be HTML, and
2. the current output actually includes `</head>`.

Previously it would just insert the LINK element at the start of the output if it couldn’t find a better place. While in most cases it will be more correct not to add it at all.

Thanks to @jeremycherfas for raising the issue and helping me out with understanding Grav.